### PR TITLE
Toggle disabled flag with the training-event-only addon

### DIFF
--- a/events/hilary-2026.yaml
+++ b/events/hilary-2026.yaml
@@ -11,7 +11,7 @@ sessions:
     topic: Version control with Git
   - date: "29 Jan"
     slot: afternoon
-    topic: Collaboration with GitHub
+    topic: Collaborative Code Development
   - date: "05 Feb"
     slot: morning
     topic: Software Testing

--- a/events/schmidt-faculty-2026.yaml
+++ b/events/schmidt-faculty-2026.yaml
@@ -11,7 +11,7 @@ sessions:
     topic: Version control with Git
   - date: "04 Feb"
     slot: afternoon
-    topic: Collaboration with GitHub
+    topic: Collaborative Code Development
   - date: "06 Feb"
     slot: morning
     topic: Software Testing

--- a/events/trinity-2026.yaml
+++ b/events/trinity-2026.yaml
@@ -11,7 +11,7 @@ sessions:
     topic: Version Control with Git
   - date: "07 May"
     slot: afternoon
-    topic: Collaboration with GitHub
+    topic: Collaborative Code Development
   - date: "14 May"
     slot: morning
     topic: Software Testing

--- a/presentations/collaborative_code_development/slides.md
+++ b/presentations/collaborative_code_development/slides.md
@@ -1,6 +1,8 @@
 ---
 theme: oxrse
 title: Collaborative Code Development
+addons:
+  - ../common/addon
 layout: cover
 highlighter: shiki
 drawings:
@@ -10,12 +12,18 @@ mdc: true
 ---
 
 ---
+
+```yaml
 layout: orientation
 title: Orientation
 highlight: Collaborative Code Development
-disabled: true
----
+training-event-only: true
+```
 
 ---
+
+```yaml
 src: ../../common/courses/collaborative_code_development/main.md
+```
+
 ---

--- a/presentations/containerisation/slides.md
+++ b/presentations/containerisation/slides.md
@@ -1,6 +1,8 @@
 ---
 theme: oxrse
 title: Containerisation with Docker
+addons:
+  - ../common/addon
 layout: cover
 highlighter: shiki
 drawings:
@@ -15,7 +17,7 @@ mdc: true
 layout: orientation
 title: Orientation
 highlight: Containerisation with Docker
-disabled: false
+training-event-only: true
 ```
 
 ---

--- a/presentations/functional/slides.md
+++ b/presentations/functional/slides.md
@@ -1,6 +1,8 @@
 ---
 theme: oxrse
 title: Functional Programming
+addons:
+  - ../common/addon
 layout: cover
 highlighter: shiki
 drawings:
@@ -8,6 +10,15 @@ drawings:
 transition: slide-left
 mdc: true
 ---
+
+---
+
+```yaml
+layout: orientation
+title: Orientation
+highlight: Functional Programming
+training-event-only: true
+```
 
 ---
 

--- a/presentations/hpc/slides.md
+++ b/presentations/hpc/slides.md
@@ -1,6 +1,8 @@
 ---
 theme: oxrse
 title: Introduction to HPC
+addons:
+  - ../common/addon
 layout: cover
 highlighter: shiki
 drawings:
@@ -15,7 +17,7 @@ mdc: true
 layout: orientation
 title: Orientation
 highlight: Introduction to HPC
-disabled: false
+training-event-only: true
 ```
 
 ---

--- a/presentations/object_oriented/slides.md
+++ b/presentations/object_oriented/slides.md
@@ -1,6 +1,8 @@
 ---
 theme: oxrse
 title: Object-Oriented Programming
+addons:
+  - ../common/addon
 layout: cover
 highlighter: shiki
 drawings:
@@ -16,7 +18,7 @@ plantUmlServer: https://www.plantuml.com/plantuml
 layout: orientation
 title: Orientation
 highlight: Object-Oriented Programming
-disabled: false
+training-event-only: true
 ```
 
 ---

--- a/presentations/packaging_dependency/slides.md
+++ b/presentations/packaging_dependency/slides.md
@@ -1,6 +1,8 @@
 ---
 theme: oxrse
 title: Packaging and Dependency Management
+addons:
+  - ../common/addon
 layout: cover
 highlighter: shiki
 drawings:
@@ -15,7 +17,7 @@ mdc: true
 layout: orientation
 title: Orientation
 highlight: Packaging and Dependency Management
-disabled: false
+training-event-only: true
 ```
 
 ---

--- a/presentations/snakemake/slides.md
+++ b/presentations/snakemake/slides.md
@@ -1,6 +1,8 @@
 ---
 theme: oxrse
 title: Workflows with Snakemake
+addons:
+  - ../common/addon
 layout: cover
 highlighter: shiki
 drawings:
@@ -8,6 +10,15 @@ drawings:
 transition: slide-left
 mdc: true
 ---
+
+---
+
+```yaml
+layout: orientation
+title: Orientation
+highlight: Workflows with Snakemake
+training-event-only: true
+```
 
 ---
 

--- a/presentations/version_control/slides.md
+++ b/presentations/version_control/slides.md
@@ -1,6 +1,8 @@
 ---
 theme: oxrse
 title: Version Control with Git
+addons:
+  - ../common/addon
 layout: cover
 highlighter: shiki
 drawings:
@@ -10,12 +12,16 @@ mdc: true
 ---
 
 ---
+
+```yaml
 layout: orientation
 title: Orientation
 highlight: Version Control with Git
-disabled: true
----
+training-event-only: true
+```
 
 ---
+
+```yaml
 src: ../../common/courses/version_control/main.md
----
+```


### PR DESCRIPTION
This PR updates the slides to use the addon which allows toggling the `disabled` frontmatter in slide depending on whether this is a training event (`TRAINING_EVENT` is set or not). 