### PR TITLE
Add feedback/Gutenburg usage slides if it is a training event

### DIFF
--- a/presentations/collaborative_code_development/slides.md
+++ b/presentations/collaborative_code_development/slides.md
@@ -27,3 +27,8 @@ src: ../../common/courses/collaborative_code_development/main.md
 ```
 
 ---
+
+```yaml
+src: ../../common/courses/epilogue/main.md
+training-event-only: true
+```

--- a/presentations/containerisation/slides.md
+++ b/presentations/containerisation/slides.md
@@ -25,3 +25,10 @@ training-event-only: true
 ```yaml
 src: ../../common/courses/containerisation/main.md
 ```
+
+---
+
+```yaml
+src: ../../common/courses/epilogue/main.md
+training-event-only: true
+```

--- a/presentations/functional/slides.md
+++ b/presentations/functional/slides.md
@@ -25,3 +25,10 @@ training-event-only: true
 ```yaml
 src: ../../common/courses/functional/main.md
 ```
+
+---
+
+```yaml
+src: ../../common/courses/epilogue/main.md
+training-event-only: true
+```

--- a/presentations/hpc/slides.md
+++ b/presentations/hpc/slides.md
@@ -25,3 +25,10 @@ training-event-only: true
 ```yaml
 src: ../../common/courses/hpc/main.md
 ```
+
+---
+
+```yaml
+src: ../../common/courses/epilogue/main.md
+training-event-only: true
+```

--- a/presentations/object_oriented/slides.md
+++ b/presentations/object_oriented/slides.md
@@ -26,3 +26,10 @@ training-event-only: true
 ```yaml
 src: ../../common/courses/object_oriented/main.md
 ```
+
+---
+
+```yaml
+src: ../../common/courses/epilogue/main.md
+training-event-only: true
+```

--- a/presentations/packaging_dependency/slides.md
+++ b/presentations/packaging_dependency/slides.md
@@ -25,3 +25,10 @@ training-event-only: true
 ```yaml
 src: ../../common/courses/packaging_dependency/main.md
 ```
+
+---
+
+```yaml
+src: ../../common/courses/epilogue/main.md
+training-event-only: true
+```

--- a/presentations/snakemake/slides.md
+++ b/presentations/snakemake/slides.md
@@ -25,3 +25,10 @@ training-event-only: true
 ```yaml
 src: ../../common/courses/snakemake/main.md
 ```
+
+---
+
+```yaml
+src: ../../common/courses/epilogue/main.md
+training-event-only: true
+```

--- a/presentations/version_control/slides.md
+++ b/presentations/version_control/slides.md
@@ -25,3 +25,10 @@ training-event-only: true
 ```yaml
 src: ../../common/courses/version_control/main.md
 ```
+
+---
+
+```yaml
+src: ../../common/courses/epilogue/main.md
+training-event-only: true
+```


### PR DESCRIPTION
This PR uses the `training-event-only` (from the addon) flag to include slides for feedback form and Gutenberg usage if this is a training event (`TRAINING_EVENT` is set).

This can be merged once `common/courses/epilogue/main.md` has the corresponding slides.