### PR TITLE
Add updated testing slides as a module, with orientation slide

### DIFF
--- a/presentations/testing/slides.md
+++ b/presentations/testing/slides.md
@@ -1,0 +1,27 @@
+---
+theme: oxrse
+title: Software Testing
+addons:
+  - ../common/addon
+layout: cover
+highlighter: shiki
+drawings:
+  persist: false
+transition: slide-left
+mdc: true
+---
+
+---
+
+```yaml
+layout: orientation
+title: Orientation
+highlight: Software Testing
+training-event-only: true
+```
+
+---
+
+```yaml
+src: ../../common/courses/testing/main.md
+```


### PR DESCRIPTION
Requires https://github.com/OxfordRSE/training-course-slides/pull/22 be merged as well.