### PR TITLE
Add AI for coding course

### DIFF
--- a/presentations/ai_for_coding/slides.md
+++ b/presentations/ai_for_coding/slides.md
@@ -1,0 +1,19 @@
+---
+theme: oxrse
+title: Using AI for Coding
+addons:
+  - ../common/addon
+  - fancy-arrow
+layout: cover
+highlighter: shiki
+drawings:
+  persist: false
+transition: slide-left
+mdc: true
+---
+
+---
+
+```yaml
+src: ../../common/courses/ai_for_coding/main.md
+```

--- a/presentations/index-metadata.yaml
+++ b/presentations/index-metadata.yaml
@@ -43,3 +43,9 @@ snakemake:
   number: 10
   description: Building reproducible computational workflows with rules, dependencies, and easy scalability.
   audience: Scalability
+ai_for_coding:
+  number: 11
+  title: Using AI for Coding
+  description: How to use modern AI tools effectively and responsibly in code development
+  audience: Tooling
+  coreOnly: true

--- a/scripts/build-index.mjs
+++ b/scripts/build-index.mjs
@@ -55,7 +55,7 @@ async function getPresentationEntries() {
     ...[...presentationDirs].filter(slug => !metadataSlugs.has(slug)).sort(),
   ]
 
-  return Promise.all(slugs.map(async (slug) => {
+  const entries = await Promise.all(slugs.map(async (slug) => {
     const metadata = courseMetadata?.[slug] ?? {}
     const hasSlides = presentationDirs.has(slug)
     const frontmatter = hasSlides ? await readPresentationFrontmatter(slug) : {}
@@ -71,8 +71,10 @@ async function getPresentationEntries() {
       href,
       available,
       ctaLabel: available ? 'Open presentation' : 'Slides not available',
+      coreOnly: Boolean(metadata.coreOnly),
     }
   }))
+  return process.env.TRAINING_EVENT ? entries.filter(p => !p.coreOnly) : entries
 }
 
 async function readEventSchedule() {


### PR DESCRIPTION
This PR adds the course 'Using AI for Coding'. After merging https://github.com/OxfordRSE/training-course-slides/pull/31, this can be merged.