### PR TITLE
Add authors to cover page in AI for coding

### DIFF
--- a/presentations/ai_for_coding/slides.md
+++ b/presentations/ai_for_coding/slides.md
@@ -1,6 +1,9 @@
 ---
 theme: oxrse
 title: Using AI for Coding
+authors:
+  - Oliver King
+  - Jack Leland
 addons:
   - ../common/addon
   - fancy-arrow


### PR DESCRIPTION
This PR adds authors @OllyK and @jackleland to the cover page of the course AI for coding, which is now supported by the `oxrse-theme-slidev`.

I am happy to be on the acknowledgement slide so don't worry about it!